### PR TITLE
Refactor type erasure & add inner accessors to CentralDifference adaptor

### DIFF
--- a/examples/deferred_rasterisation.rs
+++ b/examples/deferred_rasterisation.rs
@@ -70,7 +70,7 @@ fn main() {
     let subdivisions = 64;
 
     let torus = Torus {};
-    let central_difference = CentralDifference::new(Box::new(torus));
+    let central_difference = CentralDifference::new(torus);
 
     let mut vertices = vec![];
     let mut marcher = PointCloud::new(subdivisions);

--- a/examples/torus.rs
+++ b/examples/torus.rs
@@ -56,23 +56,27 @@ where
     let mut vertices = vec![];
     let mut indices = vec![];
 
-    let (source, shape_name) = match shape % 2 {
-        0 => (CentralDifference::new(Box::new(Torus {})), "Torus"),
-        _ => (
-            CentralDifference::new(Box::new(CubeSphere {})),
-            "Cube Sphere",
-        ),
+    let torus_source = CentralDifference::new(Torus {});
+    let cubesphere_source = CentralDifference::new(CubeSphere {});
+
+    let shape_name = match shape % 2 {
+        0 => "Torus",
+        _ => "Cube Sphere",
     };
 
     let algorithm_name = match algorithm % 2 {
         0 => {
             let mut marching_cubes = MarchingCubes::new(128);
-            marching_cubes.extract_with_normals(&source, &mut vertices, &mut indices);
+            marching_cubes.extract_with_normals(&torus_source, &mut vertices, &mut indices);
             "Marching Cubes"
         }
         _ => {
             let mut linear_hashed_marching_cubes = LinearHashedMarchingCubes::new(7);
-            linear_hashed_marching_cubes.extract_with_normals(&source, &mut vertices, &mut indices);
+            linear_hashed_marching_cubes.extract_with_normals(
+                &cubesphere_source,
+                &mut vertices,
+                &mut indices,
+            );
             "Linear Hashed Marching Cubes"
         }
     };

--- a/src/source.rs
+++ b/src/source.rs
@@ -32,14 +32,20 @@ pub trait HermiteSource: Source {
 }
 
 /// Adapts a `Source` to a `HermiteSource` by deriving normals from the surface via central differencing
-pub struct CentralDifference {
-    source: Box<Source>,
+pub struct CentralDifference<S>
+where
+    S: Source,
+{
+    source: S,
     epsilon: f32,
 }
 
-impl CentralDifference {
+impl<S> CentralDifference<S>
+where
+    S: Source,
+{
     /// Create an adaptor from a [Source](trait.Source.html)
-    pub fn new(source: Box<Source>) -> CentralDifference {
+    pub fn new(source: S) -> CentralDifference<S> {
         CentralDifference {
             source,
             epsilon: 0.0001,
@@ -47,18 +53,24 @@ impl CentralDifference {
     }
 
     /// Create an adaptor from a [Source](trait.Source.html) and an epsilon value
-    pub fn new_with_epsilon(source: Box<Source>, epsilon: f32) -> CentralDifference {
+    pub fn new_with_epsilon(source: S, epsilon: f32) -> CentralDifference<S> {
         CentralDifference { source, epsilon }
     }
 }
 
-impl Source for CentralDifference {
+impl<S> Source for CentralDifference<S>
+where
+    S: Source,
+{
     fn sample(&self, x: f32, y: f32, z: f32) -> f32 {
         self.source.sample(x, y, z)
     }
 }
 
-impl HermiteSource for CentralDifference {
+impl<S> HermiteSource for CentralDifference<S>
+where
+    S: Source,
+{
     fn sample_normal(&self, x: f32, y: f32, z: f32) -> Vec3 {
         let v = self.sample(x, y, z);
         let vx = self.sample(x + self.epsilon, y, z);

--- a/src/source.rs
+++ b/src/source.rs
@@ -56,6 +56,16 @@ where
     pub fn new_with_epsilon(source: S, epsilon: f32) -> CentralDifference<S> {
         CentralDifference { source, epsilon }
     }
+
+    /// Gets the inner source
+    pub fn inner(&self) -> &S {
+        &self.source
+    }
+
+    /// Gets the mutable inner source
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.source
+    }
 }
 
 impl<S> Source for CentralDifference<S>


### PR DESCRIPTION
I recently started building a dynamic geometry generator using the library. I wanted to use the CentralDifference adaptor but needed to access the parameters of the inner sampling function at the same time. This fixes the issue and avoids a fat-pointer vtable dynamic binding.