### PR TITLE
Update glium versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "isosurface"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Tristam MacDonald <swiftcoder@gmail.com>"]
 license = "Apache-2.0"
 description = "Isosurface extraction algorithms"
@@ -8,8 +8,8 @@ repository = "https://github.com/swiftcoder/isosurface"
 readme = "README.md"
 
 [dev-dependencies]
-glium = "0.17.0"
-glium_text_rusttype = "0.2.0"
+glium = "0.20.0"
+glium_text_rusttype = "0.3.1"
 cgmath = "0.15.0"
 
 [profile.dev]


### PR DESCRIPTION
The samples were crashing on Windows with `thread 'main' panicked at 'gl function was not loaded'`.

Most likely due to: https://github.com/glium/glium/issues/1648