### PR TITLE
Make extract implementation public

### DIFF
--- a/src/marching_cubes.rs
+++ b/src/marching_cubes.rs
@@ -47,7 +47,7 @@ impl MarchingCubes {
     where
         S: Source,
     {
-        self.extract_impl(
+        self.extract_with(
             source,
             |v: Vec3| {
                 vertices.push(v.x);
@@ -74,7 +74,7 @@ impl MarchingCubes {
     ) where
         S: HermiteSource,
     {
-        self.extract_impl(
+        self.extract_with(
             source,
             |v: Vec3| {
                 let n = source.sample_normal(v.x, v.y, v.z);
@@ -89,7 +89,14 @@ impl MarchingCubes {
         );
     }
 
-    fn extract_impl<S, E>(&mut self, source: &S, mut extract: E, indices: &mut Vec<u32>)
+    /// Extracts a mesh from the given [`HermiteSource`](../source/trait.HermiteSource.html).
+    ///
+    /// The Source will be sampled in the range (0,0,0) to (1,1,1), with the number of steps
+    /// determined by the size provided to the constructor.
+    ///
+    /// Extracted vertices will be passed to the `extract` closure. Extracted
+    /// triangles will be appended to `indices` as triples of vertex indices.
+    pub fn extract_with<S, E>(&mut self, source: &S, mut extract: E, indices: &mut Vec<u32>)
     where
         S: Source,
         E: FnMut(Vec3) -> (),

--- a/src/source.rs
+++ b/src/source.rs
@@ -53,13 +53,13 @@ impl<S: Source> CentralDifference<S> {
 }
 
 impl<S: Source> Source for CentralDifference<S> {
-    pub fn sample(&self, x: f32, y: f32, z: f32) -> f32 {
+    fn sample(&self, x: f32, y: f32, z: f32) -> f32 {
         self.source.sample(x, y, z)
     }
 }
 
 impl<S: Source> HermiteSource for CentralDifference<S> {
-    pub fn sample_normal(&self, x: f32, y: f32, z: f32) -> Vec3 {
+    fn sample_normal(&self, x: f32, y: f32, z: f32) -> Vec3 {
         let v = self.sample(x, y, z);
         let vx = self.sample(x + self.epsilon, y, z);
         let vy = self.sample(x, y + self.epsilon, z);

--- a/src/source.rs
+++ b/src/source.rs
@@ -53,13 +53,13 @@ impl<S: Source> CentralDifference<S> {
 }
 
 impl<S: Source> Source for CentralDifference<S> {
-    fn sample(&self, x: f32, y: f32, z: f32) -> f32 {
+    pub fn sample(&self, x: f32, y: f32, z: f32) -> f32 {
         self.source.sample(x, y, z)
     }
 }
 
 impl<S: Source> HermiteSource for CentralDifference<S> {
-    fn sample_normal(&self, x: f32, y: f32, z: f32) -> Vec3 {
+    pub fn sample_normal(&self, x: f32, y: f32, z: f32) -> Vec3 {
         let v = self.sample(x, y, z);
         let vx = self.sample(x + self.epsilon, y, z);
         let vy = self.sample(x, y + self.epsilon, z);


### PR DESCRIPTION
Makes the `extract_impl` function public, renamed to `extract_with` which allows passing of a closure so custom behaviour can be defined per vertex. (ie. for generating a separate vec of normals.)